### PR TITLE
Initial CLI

### DIFF
--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -3,14 +3,14 @@ import sys
 
 
 @click.command()
+@click.option('--acme',
+              help='The address for the ACME Directory Resource',
+              default='https://acme-v01.api.letsencrypt.org/directory',
+              show_default=True)
 @click.option('--email',
               help='Email address for Let\'s Encrypt certificate registration '
                    'and recovery contact',
               required=True)
-@click.option('--server',
-              help='The address for the ACME Directory Resource',
-              default='https://acme-v01.api.letsencrypt.org/directory',
-              show_default=True)
 @click.option('--storage-dir',
               help='Path to directory for storing certificates')
 @click.option('--marathon', default='http://marathon.service.consul:8080',
@@ -30,7 +30,7 @@ import sys
 @click.option('--consul', default='http://consul.service.consul:8500',
               help='The address for the Consul HTTP API',
               show_default=True)
-@click.option('--consul-prefix', default='certbot',
+@click.option('--kv-prefix', default='certbot',
               help='Prefix for all paths to certificates in Consul\'s '
                    'key/value store',
               show_default=True)
@@ -45,9 +45,9 @@ import sys
 @click.option('--debug',
               help='Log debug output',
               is_flag=True)
-def main(email, server, storage_dir,         # Certificates
+def main(acme, email, storage_dir,           # ACME
          marathon, listen, port, advertise,  # Marathon
-         consul, consul_prefix, poll,        # Consul
+         consul, kv_prefix, poll,            # Consul
          logfile, debug):                    # Logging
     """
     A tool to automatically request, renew and distribute Let's Encrypt

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -9,31 +9,37 @@ import sys
               required=True)
 @click.option('--server',
               help='The address for the ACME Directory Resource',
-              default='https://acme-v01.api.letsencrypt.org/directory')
+              default='https://acme-v01.api.letsencrypt.org/directory',
+              show_default=True)
 @click.option('--storage-dir',
               help='Path to directory for storing certificates')
 @click.option('--marathon', default='http://marathon.service.consul:8080',
-              help='The address for the Marathon HTTP API')
+              help='The address for the Marathon HTTP API',
+              show_default=True)
 @click.option('--listen',
               help='The address of the interface to bind to to receive '
                    'Marathon\'s event stream',
-              default='0.0.0.0')
-@click.option('--port', default='7000', type=int,
+              default='0.0.0.0',
+              show_default=True)
+@click.option('--port', default='7000', type=int, show_default=True,
               help='The port to bind to to receive Marathon\'s event stream')
 @click.option('--advertise', default='http://certbot.service.consul',
               help='The address to advertise to Marathon when registering for '
-                   'the event stream')
+                   'the event stream',
+              show_default=True)
 @click.option('--consul', default='http://consul.service.consul:8500',
-              help='The address for the Consul HTTP API')
+              help='The address for the Consul HTTP API',
+              show_default=True)
 @click.option('--consul-prefix', default='certbot',
               help='Prefix for all paths to certificates in Consul\'s '
-                   'key/value store')
+                   'key/value store',
+              show_default=True)
 @click.option('--poll',
               help='Periodically sync Marathon\'s state with Consul\'s every '
-                   '_n_ seconds',
+                   '_n_ seconds [default: disabled]',
               type=int)
 @click.option('--logfile',
-              help='Where to log output to (default stdout)',
+              help='Where to log output to [default: stdout]',
               type=click.File('a'),
               default=sys.stdout)
 @click.option('--debug',

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -7,6 +7,9 @@ import sys
               help='Email address for Let\'s Encrypt certificate registration '
                    'and recovery contact',
               required=True)
+@click.option('--server',
+              help='The address for the ACME Directory Resource',
+              default='https://acme-v01.api.letsencrypt.org/directory')
 @click.option('--storage-dir',
               help='Path to directory for storing certificates')
 @click.option('--marathon', default='http://marathon.service.consul:8080',
@@ -36,7 +39,7 @@ import sys
 @click.option('--debug',
               help='Log debug output',
               is_flag=True)
-def main(email, storage_dir,                 # Certificates
+def main(email, server, storage_dir,         # Certificates
          marathon, listen, port, advertise,  # Marathon
          consul, consul_prefix, poll,        # Consul
          logfile, debug):                    # Logging

--- a/certbot/cli.py
+++ b/certbot/cli.py
@@ -1,0 +1,46 @@
+import click
+import sys
+
+
+@click.command()
+@click.option('--email',
+              help='Email address for Let\'s Encrypt certificate registration '
+                   'and recovery contact',
+              required=True)
+@click.option('--storage-dir',
+              help='Path to directory for storing certificates')
+@click.option('--marathon', default='http://marathon.service.consul:8080',
+              help='The address for the Marathon HTTP API')
+@click.option('--listen',
+              help='The address of the interface to bind to to receive '
+                   'Marathon\'s event stream',
+              default='0.0.0.0')
+@click.option('--port', default='7000', type=int,
+              help='The port to bind to to receive Marathon\'s event stream')
+@click.option('--advertise', default='http://certbot.service.consul',
+              help='The address to advertise to Marathon when registering for '
+                   'the event stream')
+@click.option('--consul', default='http://consul.service.consul:8500',
+              help='The address for the Consul HTTP API')
+@click.option('--consul-prefix', default='certbot',
+              help='Prefix for all paths to certificates in Consul\'s '
+                   'key/value store')
+@click.option('--poll',
+              help='Periodically sync Marathon\'s state with Consul\'s every '
+                   '_n_ seconds',
+              type=int)
+@click.option('--logfile',
+              help='Where to log output to (default stdout)',
+              type=click.File('a'),
+              default=sys.stdout)
+@click.option('--debug',
+              help='Log debug output',
+              is_flag=True)
+def main(email, storage_dir,                 # Certificates
+         marathon, listen, port, advertise,  # Marathon
+         consul, consul_prefix, poll,        # Consul
+         logfile, debug):                    # Logging
+    """
+    A tool to automatically request, renew and distribute Let's Encrypt
+    certificates for apps running on Seed Stack.
+    """

--- a/certbot/tests/test_cli.py
+++ b/certbot/tests/test_cli.py
@@ -1,0 +1,27 @@
+import re
+
+from click.testing import CliRunner
+
+from certbot.cli import main
+
+
+def test_email_required():
+    """
+    The program is expected to exit with an error code and message if '--email'
+    is not provided.
+    """
+    runner = CliRunner()
+    result = runner.invoke(main, [])
+
+    assert result.exit_code == 2
+    assert re.search('Error: Missing option "--email"', result.output)
+
+
+def test_email_provided():
+    """
+    The program is expected to exit with code 0 if '--email' is provided.
+    """
+    runner = CliRunner()
+    result = runner.invoke(main, ['--email', 'test@example.com'])
+
+    assert result.exit_code == 0

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     author_email='jamie@praekelt.com',
     packages=find_packages(),
     install_requires=[
+        'click',
         'treq',
         'Twisted',
         'uritools>=1.0.0'
@@ -23,4 +24,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
     ],
+    entry_points={
+        'console_scripts': ['certbot = certbot.cli:main'],
+    }
 )


### PR DESCRIPTION
This is just what I think the CLI should look like. I may be getting slightly ahead of myself. There are a few things I've learnt from the Consular CLI and have made simpler (removed timeout and fallback options, removed `--purge` - want to make that default behaviour, renamed some things, added `--advertise` for better Docker compatibility).

For  reference, [here](https://github.com/universalcore/consular/blob/develop/consular/cli.py#L7-L51) is the Consular CLI code.

```
> $ certbot --help
Usage: certbot [OPTIONS]

  A tool to automatically request, renew and distribute Let's Encrypt
  certificates for apps running on Seed Stack.

Options:
  --email TEXT          Email address for Let's Encrypt certificate
                        registration and recovery contact  [required]
  --storage-dir TEXT    Path to directory for storing certificates
  --marathon TEXT       The address for the Marathon HTTP API
  --listen TEXT         The address of the interface to bind to to receive
                        Marathon's event stream
  --port INTEGER        The port to bind to to receive Marathon's event stream
  --advertise TEXT      The address to advertise to Marathon when registering
                        for the event stream
  --consul TEXT         The address for the Consul HTTP API
  --consul-prefix TEXT  Prefix for all paths to certificates in Consul's
                        key/value store
  --poll INTEGER        Periodically sync Marathon's state with Consul's every
                        _n_ seconds
  --logfile FILENAME    Where to log output to (default stdout)
  --debug               Log debug output
  --help                Show this message and exit.
```